### PR TITLE
fixing error TS2428 with tsc 2.0

### DIFF
--- a/lib/services/table/tableutilities.d.ts
+++ b/lib/services/table/tableutilities.d.ts
@@ -183,7 +183,7 @@ export namespace entityGenerator {
 
         constructor(value: T, type?: string);
     }
-    export interface EntityProperty {
+    export interface EntityPropertyInterface {
         <T>(): EntityProperty<T>;
     }
 

--- a/typings.json
+++ b/typings.json
@@ -2,6 +2,6 @@
     "name": "azure-storage",
     "main": "lib/azure-storage.d.ts",
     "globalDependencies": {
-        "node": "registry:dt/node#6.0.0+20160514165920"
+        "node": "registry:dt/node#7.0.0+20170110233017"
     }
 }


### PR DESCRIPTION
There is a [reported error](https://github.com/Azure/azure-storage-node/issues/230) with tsc 2.0.3+.
It is "error TS2428" and it is because an interface and a class named exactly the same.
Also I updated the version of type file for node.


